### PR TITLE
upgrade sphinx version to 3.5.4 to fix dependency issue and add PA6 a…

### DIFF
--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -32,6 +32,11 @@
 			gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
+		custom_relay_1: relay_1 {
+			gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
+			label = "User RE1";
+		};
 	};
 
 	gpio_keys {
@@ -45,6 +50,7 @@
 	aliases {
 		led0 = &green_led_2;
         led1 = &custom_led_3;
+		relay1 = &custom_relay_1;
 		sw0 = &user_button;
 	};
 };

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,7 @@
 # DOC: used to generate docs
 
 breathe~=4.23,!=4.29.0
-sphinx~=3.3
+sphinx~=3.5.4
 sphinx_rtd_theme>=0.5.2,<1.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Add PA6 as relay1, connect extra 2 relays,
so we can turn on and off the charger touch pads to avoid sparkle