### PR TITLE
olimexino stm32f303 support

### DIFF
--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -32,6 +32,11 @@
 			gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
+		custom_relay_1: relay_1 {
+			gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
+			label = "User RE1";
+		};
 	};
 
 	gpio_keys {
@@ -45,6 +50,7 @@
 	aliases {
 		led0 = &green_led_2;
         led1 = &custom_led_3;
+		relay1 = &custom_relay_1;
 		sw0 = &user_button;
 	};
 };

--- a/boards/arm/olimexino_stm32f303rc/Kconfig.board
+++ b/boards/arm/olimexino_stm32f303rc/Kconfig.board
@@ -1,0 +1,8 @@
+# NUCLEO-64 F303RE board configuration
+
+# Copyright (c) 2020 Paul M. Bendixen
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_OLIMEXINO_STM32F303RC
+	bool "Olimexino STM32F303RC Development Board"
+	depends on SOC_STM32F303XC

--- a/boards/arm/olimexino_stm32f303rc/Kconfig.defconfig
+++ b/boards/arm/olimexino_stm32f303rc/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# Olimexino STM32F303RC board configuration
+
+# Copyright (c) 2020 Paul M. Bendixen
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_OLIMEXINO_STM32F303RC
+
+config BOARD
+	default "olimexino_stm32f303rc"
+
+endif # BOARD_OLIMEXINO_STM32F303RC

--- a/boards/arm/olimexino_stm32f303rc/board.cmake
+++ b/boards/arm/olimexino_stm32f303rc/board.cmake
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(stm32flash "--baud-rate=115200" "--start-addr=0x08000000")
+board_runner_args(jlink "--device=STM32F303RC" "--speed=4000")
+
+include(${ZEPHYR_BASE}/boards/common/stm32flash.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/olimexino_stm32f303rc/doc/index.rst
+++ b/boards/arm/olimexino_stm32f303rc/doc/index.rst
@@ -1,0 +1,116 @@
+.. _nucleo_f303rc_board:
+
+ST Nucleo F303RC
+################
+
+Overview
+********
+
+The Olimexino STM32F303RC board features an ARM Cortex-M4 based STM32F303RC
+mixed-signal MCU with FPU and DSP instructions capable of running at 72 MHz.
+Here are some highlights of the Olimexino STM32F303RC board:
+
+- STM32 microcontroller in LQFP64 package
+- LSE crystal: 32.768 kHz crystal oscillator
+- Two types of extension resources:
+
+  - Arduino* Uno V3 connectors
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
+- On-board ST-LINK/V2-1 debugger/programmer with SWD connector
+- Flexible board power supply:
+
+  - 5 V from ST-LINK/V2-1 USB VBUS
+  - External power sources: 3.3 V and 7 - 12 V on ST Zio or ST morpho
+    connectors, 5 V on ST morpho connector
+
+- One user LED
+- Two push-buttons: USER and RESET
+
+More information about the board can be found at the `Olimexino STM32F303RC website`_.
+Hardware
+********
+
+The Nucleo F303RC provides the following hardware components:
+
+- STM32F303RCT6 in QFP64 package
+- ARM |reg| 32-bit Cortex |reg| -M4 CPU with FPU
+- 72 MHz max CPU frequency
+- VDD from 2.0 V to 3.6 V
+- 256 KB Flash
+- 32 + 8 KB SRAM
+- RTC
+- Advanced-control Timer
+- General Purpose Timers (4)
+- Basic Timer
+- Watchdog Timers (2)
+- PWM channels (18)
+- SPI/I2S (2)
+- I2C (3)
+- USART/UART (3/3)
+- USB 2.0 FS with on-chip PHY
+- CAN (2)
+- GPIO with external interrupt capability
+- DMA channels (12)
+- Capacitive sensing channels (18)
+- 12-bit ADC with 40 channels (4)
+- 12-bit D/A converter with two channels
+- Analog comparator (7)
+- Op amp (4)
+- Capacitive sensing 24 channels
+
+
+More information about the STM32F303RC can be found here:
+
+- `STM32F303RC on www.st.com`_
+- `STM32F303RC reference manual`_
+- `STM32F303RC datasheet`_
+
+Supported Features
+==================
+
+The default configuration can be found in the defconfig file:
+``boards/arm/nucleo_f303rc/nucleo_f303rc_defconfig``
+
+Connections and IOs
+===================
+
+The Olimexino STM32F303RC Board has 5 GPIO controllers. These controllers are
+responsible for pin muxing, input/output, pull-up, etc.
+
+Default Zephyr Peripheral Mapping:
+----------------------------------
+
+The Olimexino STM32F303RC board features an Arduino Uno V3 connector and a ST
+morpho connector. Board is configured as follows:
+
+- UART_2 TX/RX : PA2/PA3 (ST-Link Virtual Port Com)
+- USER_PB   : PC13
+- LD2       : PA5
+
+System Clock
+------------
+
+The STM32F303RC System Clock can be driven by an internal or
+external oscillator, as well as by the main PLL clock. By default the
+System Clock is driven by the PLL clock at 72 MHz. The input to the
+PLL is an 8 MHz external clock supplied by the processor of the
+on-board ST-LINK/V2-1 debugger/programmer.
+
+Serial Port
+-----------
+
+The Olimexino STM32F303RE board has 2 UARTs. The Zephyr console output is assigned
+to UART2.  Default settings are 115200 8N1.
+
+.. _Olimexino STM32F303RC website:
+   https://www.olimex.com/Products/Duino/STM32/OLIMEXINO-STM32F3/open-source-hardware
+
+.. _STM32F303RC on www.st.com:
+   http://www.st.com/en/microcontrollers/stm32f303rc.html
+
+.. _STM32F303RC reference manual:
+   https://www.st.com/resource/en/reference_manual/dm00043574.pdf
+
+.. _STM32F303RC datasheet:
+   http://www.st.com/resource/en/datasheet/stm32f303rc.pdf

--- a/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc.dts
+++ b/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc.dts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2020 Paul M. Bendixen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <st/f3/stm32f303Xc.dtsi>
+#include <st/f3/stm32f303r(b-c)tx-pinctrl.dtsi>
+
+/ {
+	model = "Olimex OLIMEXINO-STM32F303RC board";
+	compatible = "olimex,olimexino_stm32f303rc", "st,stm32f303rc";
+
+	chosen {
+		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,can-primary = &can1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		green_led_2: led_2 {
+			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
+			label = "User LD2";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_button: button {
+			label = "User";
+			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		led0 = &green_led_2;
+		led1 = &green_led_2;
+		sw0 = &user_button;
+	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(8)>;
+	status = "okay";
+};
+
+&pll {
+	prediv = <1>;
+	mul = <9>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(72)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <2>;
+	apb2-prescaler = <1>;
+};
+
+uext_i2c: &i2c2 {};
+uext_spi: &spi1 {};
+uext_serial: &usart3 {};
+
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pc4 &usart1_rx_pc5>;
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart2 {
+	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart3 {
+	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
+		      &spi1_miso_pa6 &spi1_mosi_pa7>;
+	status = "okay";
+};
+
+&spi2 {
+	pinctrl-0 = <&spi2_nss_pb12 &spi2_sck_pb13
+		      &spi2_miso_pb14 &spi2_mosi_pb15>;
+	status = "okay";
+	cs-gpios = <&gpiod 2 GPIO_ACTIVE_HIGH>;
+
+	sdhc0: sdhc@0 {
+		compatible = "zephyr,mmc-spi-slot";
+		reg = <0>;
+		status = "okay";
+		label = "SDHC0";
+		spi-max-frequency = <24000000>;
+	};
+};
+
+&usb {
+	status = "okay";
+	disconnect-gpios = <&gpioc 12 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+};
+
+&timers1 {
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim1_ch1_pa8>;
+	};
+};
+
+&iwdg {
+	status = "okay";
+};
+
+&can1 {
+	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
+	bus-speed = <125000>;
+	sjw = <1>;
+	prop-seg = <0>;
+	phase-seg1 = <5>;
+	phase-seg2 = <6>;
+	status = "okay";
+};
+
+&flash0 {
+
+    partitions {
+        compatible = "fixed-partitions";
+        #address-cells = <1>;
+        #size-cells = <1>;
+
+        boot_partition: partition@0 {
+            label = "mcuboot";
+            reg = <0x08000000 0x00010000>;
+            read-only;
+        };
+
+        /*
+         * The flash starting at 0x00010000 and ending at
+         * 0x0001ffff (sectors 16-31) is reserved for use
+         * by the application.
+         */
+        storage_partition: partition@10000 {
+            label = "storage";
+            reg = <0x00010000 0x00010000>;
+        };
+
+        slot0_partition: partition@20000 {
+            label = "image-0";
+            reg = <0x00020000 0x00020000>;
+        };
+        slot1_partition: partition@40000 {
+            label = "image-1";
+            reg = <0x00040000 0x00020000>;
+        };
+        scratch_partition: partition@60000 {
+            label = "image-scratch";
+            reg = <0x00060000 0x00020000>;
+        };
+    };
+};

--- a/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc.yaml
+++ b/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc.yaml
@@ -1,0 +1,19 @@
+identifier: olimexino_stm32f303rc
+name: Olimexino STM32F303RC
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+ram: 40
+flash: 256
+supported:
+  - gpio
+  - i2c
+  - pwm
+  - sdhc
+  - spi
+  - usb_device
+  - watchdog
+  - can

--- a/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc_defconfig
+++ b/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc_defconfig
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_STM32F3X=y
+CONFIG_SOC_STM32F303XC=y
+
+CONFIG_SERIAL=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable HW stack protection
+# CONFIG_HW_STACK_PROTECTION=y
+
+# console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# enable pinmux
+CONFIG_PINMUX=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable Clocks
+CONFIG_CLOCK_CONTROL=y

--- a/boards/arm/olimexino_stm32f303rc/support/openocd.cfg
+++ b/boards/arm/olimexino_stm32f303rc/support/openocd.cfg
@@ -1,0 +1,10 @@
+#source [find interface/ftdi/mbftdi.cfg]
+interface ftdi
+ftdi_vid_pid 0x0403 0x6015
+ftdi_channel 0
+ftdi_layout_init 0x0038 0x003b
+
+transport select swd
+adapter_khz 200
+
+source [find target/stm32f3x.cfg]

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,7 @@
 # DOC: used to generate docs
 
 breathe~=4.23,!=4.29.0
-sphinx~=3.3
+sphinx~=3.5.4
 sphinx_rtd_theme>=0.5.2,<1.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Comparison between Olimexino STM32F303 vs Nucleo F446RE:

Advantages:
- onboard CAN transceiver, which means a lot less wiring where something can go wrong
- 9-30V power input
- much smaller form factor

Disadvantages:
- no working /dev/ttyACM0 yet
- SWD interface does not work with cheap ST-Link clones